### PR TITLE
Bump dependencnes & devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,19 +20,19 @@
     "coveralls": "istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- -R spec && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage"
   },
   "dependencies": {
-    "through2": "*",
-    "gulp-util": "~2.2.0",
     "fixmyjs": "~0.13.1",
+    "gulp-util": "^3.0.1",
     "jshint": "~2.5.0",
-    "rcloader": "~0.1.2"
+    "rcloader": "~0.1.2",
+    "through2": "*"
   },
   "devDependencies": {
-    "mocha": "*",
     "coveralls": "*",
-    "mocha-lcov-reporter": "*",
-    "istanbul": "*",
     "event-stream": "*",
-    "should": "~2.1.0"
+    "istanbul": "*",
+    "mocha": "*",
+    "mocha-lcov-reporter": "*",
+    "should": "^4.0.4"
   },
   "engines": {
     "node": ">=0.9.0",


### PR DESCRIPTION
Noticed you had a few deps that could be updated. Quick PR for them in case it's of help :)

Outdated Dependencies:
gulp-util (package: ~2.2.0, latest: 3.0.1)

Outdated Dev Dependencies:
should (package: ~2.1.0, latest: 4.0.4)
